### PR TITLE
fix the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To use, point `jshint` at the reporter
 ### Command Line
 
 ```
-jshint --reporter node_modules/jshint-teamcity-compile *.js
+jshint --reporter node_modules/jshint-teamcity-compile/teamcity.js *.js
 ```
 
 ### Using [gulp-jshint](https://www.npmjs.org/package/gulp-jshint)


### PR DESCRIPTION
For some reason it is not working without specifying the file name, I see that it work this way in another modules. 
